### PR TITLE
Feature/plugin http

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,8 @@
                 "accept",
                 "--debug",
                 "--log_level", "6",
-                "--config", "samples/filebeat.yaml",
-                "--pipeline", "beats"
+                "--config", "samples/webhook.yaml",
+                "--pipeline", "webhook"
             ]
         },
         {

--- a/plugins/http/input/httpWebHook.py
+++ b/plugins/http/input/httpWebHook.py
@@ -1,0 +1,87 @@
+import uvicorn
+import json
+from classes import input
+
+EMPTY_RESPONSE = {
+    'type': 'http.response.body',
+    'body': b''
+}
+
+class httpWebHook(input.input):
+
+    def __init__(self,**kwargs):
+        self.bindAddress = kwargs.get("bind_address","127.0.0.1")
+        self.bindPort = kwargs.get("bind_port",5656)
+        self.path = kwargs.get("path",None)
+        self.contentType = kwargs.get("content_type","json")
+        self.authParameter = kwargs.get("authentication_parameter",None)
+        self.authHeader = kwargs.get("authentication_header",None)
+        self.customHeaders = []
+        if kwargs.get("headers",None):
+            for headerName, headerValue in kwargs.get("headers",{}).items():
+                self.customHeaders.append([headerName.encode('UTF-8'), headerValue.encode('UTF-8')])
+        super().__init__(**kwargs)
+
+    def start(self):
+        super().start()
+        uvicorn.run(self,host=self.bindAddress,port=self.bindPort)
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "http":
+            if self.customHeaders and scope['method'] == "HEAD":
+                await send(self.generateHeaders(200))
+                await send(EMPTY_RESPONSE)
+                return
+            elif scope['method'] in ("GET", "POST"):
+                if self.path and scope['path'] != self.path:
+                    await send(self.generateHeaders(403))
+                    await send(EMPTY_RESPONSE)
+                    return
+                if self.authParameter:
+                    queryParams = dict(param.split('=') for param in scope.get('query_string', b'').decode('utf-8').split('&') if '=' in param)
+                    for parameter, value in self.authParameter.items():
+                        if queryParams.get(parameter) != value:
+                            await send(self.generateHeaders(403))
+                            await send(EMPTY_RESPONSE)
+                            return
+                if self.authHeader:
+                    headers = { header.decode('utf-8') : value.decode('utf-8') for header, value in scope.get('headers', []) }
+                    for header, value in self.authHeader.items():
+                        if headers.get(header) != value:
+                            await send(self.generateHeaders(403))
+                            await send(EMPTY_RESPONSE)
+                            return  
+                getBody = True
+                body = ''
+                while getBody:
+                    msg = await receive()
+                    body += msg.get('body', '').decode('utf-8')
+                    getBody = msg.get('moreBody', False)
+                if self.contentType == "json":
+                    try:
+                        events = json.loads(body)
+                        if type(events) == list:
+                            for event in events:
+                                self.event(event)
+                        else:
+                            self.event(events)
+                    except:
+                        pass
+                events = body.split('\n')
+                for event in events:
+                    self.event(event)
+                await send(self.generateHeaders(200))
+                await send(EMPTY_RESPONSE)
+                return
+            await send(self.generateHeaders(403))
+            await send(EMPTY_RESPONSE)
+
+    def generateHeaders(self, status=200):
+        obj = {
+            'type': 'http.response.start',
+            'status': status,
+            'headers': []
+        }
+        obj['headers'].extend(self.customHeaders)
+        return obj
+    

--- a/plugins/http/input/httpWebHook.py
+++ b/plugins/http/input/httpWebHook.py
@@ -12,6 +12,10 @@ class httpWebHook(input.input):
     def __init__(self,**kwargs):
         self.bindAddress = kwargs.get("bind_address","127.0.0.1")
         self.bindPort = kwargs.get("bind_port",5656)
+        self.ssl = kwargs.get("ssl",False)
+        self.sslCertificate = kwargs.get("ssl_certificate",None)
+        self.sslPrivateKey = kwargs.get("ssl_private_key",None)
+        self.sslPrivateKeyPassword = kwargs.get("ssl_private_key_password",None)
         self.path = kwargs.get("path",None)
         self.contentType = kwargs.get("content_type","json")
         self.authParameter = kwargs.get("authentication_parameter",None)
@@ -24,7 +28,13 @@ class httpWebHook(input.input):
 
     def start(self):
         super().start()
-        uvicorn.run(self,host=self.bindAddress,port=self.bindPort)
+        additionalKwargs = {}
+        if self.ssl:
+            additionalKwargs["ssl_certfile"] = self.sslCertificate
+            additionalKwargs["ssl_keyfile"] = self.sslPrivateKey
+            if self.sslPrivateKeyPassword:
+                additionalKwargs["ssl-keyfile-password"] = self.sslPrivateKeyPassword
+        uvicorn.run(self,host=self.bindAddress,port=self.bindPort,**additionalKwargs)
 
     async def __call__(self, scope, receive, send):
         if scope.get("type") == "http":

--- a/plugins/http/output/httpRequest.py
+++ b/plugins/http/output/httpRequest.py
@@ -1,0 +1,48 @@
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+from classes import output
+from process import postRegister
+
+class httpRequest(output.output):
+
+    def __init__(self,**kwargs):
+        self.url = kwargs.get("url",None)
+        self.verify = kwargs.get("verify",True)
+        self.method = kwargs.get("method","GET")
+        self.bulk = kwargs.get("bulk",False)
+        self.useSession = kwargs.get("use_session",False)
+        self.bulkMaxEvents = kwargs.get("bulk_max_events",0)
+        self.headers = kwargs.get("headers",{})
+        self.expectedStatusCode = kwargs.get("status_code",200)
+        self.buffer = []
+        if self.bulk:
+            postRegister.items.add(self.onEnd)
+        if self.useSession:
+            self.session = requests.Session()
+        super().__init__(**kwargs)
+
+    def process(self,event):
+        self.buffer.append(event)
+        if self.bulk:
+            if self.bulkMaxEvents > 0 and len(self.buffer) >= self.bulkMaxEvents:
+                self.flush(self.buffer)
+        else:
+            self.flush(self.buffer)
+
+    def onEnd(self):
+        self.flush()
+    
+    def flush(self):
+        if len(self.buffer) > 0:
+            if len(self.buffer) == 1 and type(self.buffer[0]) == dict:
+                self.buffer = self.buffer[0]
+            request = requests.request
+            if self.useSession:
+                request = self.session.request
+            response = request(self.method,self.url,json=self.buffer,verify=self.verify,headers=self.headers)
+            if response.status_code != self.expectedStatusCode:
+                self.logger.log(10,"Unexpected response status code",{ "status_code" : response.status_code, "expected_status_code" : self.expectedStatusCode, "url" : self.url, "response" : response.text },extra={ "source" : "httpRequest", "type" : "error" })
+        self.buffer = []

--- a/plugins/http/requirements.txt
+++ b/plugins/http/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/plugins/http/requirements.txt
+++ b/plugins/http/requirements.txt
@@ -1,1 +1,2 @@
 requests
+uvicorn

--- a/samples/webhook.yaml
+++ b/samples/webhook.yaml
@@ -1,0 +1,26 @@
+input:
+  id: webhook1
+  name: webhook1
+  type: httpWebHook
+  flush_interval: 10
+  bind_port: 5656
+  next: ["loadJson"]
+
+input:
+  id: webhook2
+  name: webhook2
+  type: httpWebHook
+  flush_interval: 10
+  authentication_parameter: { "auth": "123" }
+  bind_port: 5657
+  next: ["loadJson"]
+
+processor:
+  id: loadJson
+  type: loadJson
+  next: ["stdout"]
+
+output:
+  id: stdout
+  type: stdout
+  name: stdout

--- a/utilities/httpSend.py
+++ b/utilities/httpSend.py
@@ -1,0 +1,7 @@
+import requests
+import json
+
+body = { "test" : "1", "test1" : "2", "test3" : "3" }
+
+response = requests.post("http://127.0.0.1:5657/?auth=123", data=json.dumps(body))
+print(response.status_code)


### PR DESCRIPTION
Plugin to support input from HTTP/S web hooks, as well as output events to a HTTP/S endpoint

# httpRequest

Send event output to an API

## Example

```
output:
  id: <id>
  type: httpRequest
  url: http://127.0.0.1/events
  method: POST
```

## Options

| Name | Deception | Default |
| - | - | - |
| url | API endpoint to send the events | None |
| verify | when using HTTPS enable verify of SSL certificates | True |
| method | GET,POST,PUT |GET |
| bulk | When True events will be sent as a list of events | False |
| bulk_max_events | Number of events to include in the list when using bulk, 0 for unlimited | 0 |
| use_session | Enable to keep connections, cookies, and other session state between requests | False |
| headers | Optional headers to include in the request | {} |
| status_code | Expected status code, otherwise an error is logged | 200 |

# httpWebHook

Accept incoming events over HTTP/S

## Example

```
input:
  id: <id>
  type: httpWebHook
  bind_address: 0.0.0.0
  bind_port: 8080
```

## Options

| Name | Deception | Default |
| - | - | - |
| bind_address | Address to bind the web server socket to | 127.0.0.1 |
| bind_port | TCP port to bind the web server socket to | 5656 |
| ssl | Enable to enable SSL mode, when enabled certificate and private key MUST be provided | False |
| ssl_certificate | Path to certificate | None |
| ssl_private_key | Path to certificate private key | None |
| ssl_private_key_password | Password for private key if required | None |
| content_type | When 'json' payload body will be parsed as json supporting list of events; otherwise body will be split by new line per event | json |
| authentication_parameter | Key/Value URL parameters that must match the request otherwise 403 is returned | None |
| authentication_header | Header/Value that must be included and match in the request otherwise a 403 is retuned | None |


