### PR TITLE
Refactor merge process to handle field deletion more gracefully

### DIFF
--- a/plugins/core/processor/merge.py
+++ b/plugins/core/processor/merge.py
@@ -13,4 +13,8 @@ class merge(processor.processor):
             fieldValue = typecast.getField(self.field,event)
             if type(event) is dict and type(fieldValue) is dict:
                 event.update(fieldValue)
+                try:
+                    del event[self.field]
+                except KeyError:
+                    pass
         return event


### PR DESCRIPTION
Json that is merged into the main event is not removed.

This change ensures that merged json is removed if the field is of standard selection type