### PR TITLE
Refactor loadJson process method to improve error handling for string…

### DIFF
--- a/plugins/core/processor/loadJson.py
+++ b/plugins/core/processor/loadJson.py
@@ -21,10 +21,14 @@ class loadJson(processor.processor):
             fieldValue = event
             
         if fieldValue:
-            if self.singleQuoteSupport:
-                fieldValue = ast.literal_eval(fieldValue)
-            else:
-                fieldValue = json.loads(fieldValue,strict=self.strict)
+            if type(fieldValue) is str:
+                try:
+                    if self.singleQuoteSupport:
+                        fieldValue = ast.literal_eval(fieldValue)
+                    else:
+                        fieldValue = json.loads(fieldValue,strict=self.strict)
+                except:
+                    fieldValue = { "decode_error" : fieldValue }
             fieldValue = typecast.flatten(fieldValue)
             if self.outputField and type(event) is dict:
                 event[self.outputField] = fieldValue


### PR DESCRIPTION
Loading json would fail if type was already json which could happen if a path before this includes a typecast, this now handles this 